### PR TITLE
Update gem dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
-source "http://rubygems.org"
+source "https://rubygems.org"
 
 gemspec

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,4 +1,3 @@
-require 'rubygems'
 require 'bundler'
 begin
   Bundler.setup(:default, :development)

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -8,7 +8,7 @@ rescue Bundler::BundlerError => e
   exit e.status_code
 end
 require 'test/unit'
-require 'mocha'
+require 'mocha/test_unit'
 
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib', '..'))
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))

--- a/zoopla.gemspec
+++ b/zoopla.gemspec
@@ -19,9 +19,10 @@ Gem::Specification.new do |s|
   s.licenses = ["MIT"]
   s.rubygems_version = %q{1.3.7}
 
-  s.add_dependency(%q<hashie>, ["~> 1.0.0"])
-  s.add_dependency(%q<curb>, ["~> 0.7.12"])
-  s.add_dependency(%q<json>, ["~> 1.4.3"])
+  s.add_dependency 'hashie', '~> 3.4'
+  s.add_dependency 'curb', '~> 0.8'
+  s.add_dependency 'json', '~> 1.8'
 
-  s.add_development_dependency(%q<mocha>, ["~>  0.9.12"])
+  s.add_development_dependency 'mocha', '~> 1.0'
+  s.add_development_dependency 'test-unit', '~> 3.0'
 end


### PR DESCRIPTION
Since the gem hasn't had any updates for 4 years and I needed to use
it... I decided to contribute. All the dependencies have been update
since the gem was originally created. And in the gemspec file they've
been locked down pretty tight. I've added somewhat looser constraints,
while allowing the gem to build and run with the latest stable Ruby
2.2.1.

Also this line:
https://github.com/shadchnev/zoopla/blob/master/test/test_api.rb#L36

and this line:
https://github.com/shadchnev/zoopla/blob/master/test/test_api.rb#L43

define the same test name, so Test Unit throws this error when

`rake test`

is run:

```
Started
.N
===============================================================================
TestAPI#test_actual_location_fallback was redefined [test_actual_location_fallback(TestAPI)]
/Users/alex/dev/ruby/zoopla/test/test_api.rb:67:in `<class:TestAPI>'
===============================================================================
...............................................

Finished in 0.027138 seconds.

48 tests, 159 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 1 notifications
100% passed

1768.74 tests/s, 5858.94 assertions/s
```

Maybe a rename would be in order? Not sure what would be the best name to go with.

Also removed the explicit require of RubyGems, see the commit message for details.
And set HTTPS for gem handling in the Gemfile.
